### PR TITLE
open linguee tab next to origin

### DIFF
--- a/contextAction.js
+++ b/contextAction.js
@@ -1,8 +1,6 @@
 function getword(info,tab) {
     chrome.storage.sync.get(["targetLang"], (items) => {
-        chrome.tabs.create({  
-            url: "https://" + domainMap[items.targetLang] + "/search?source=auto&query=" + info.selectionText,
-        });
+      window.open("https://" + domainMap[items.targetLang] + "/search?source=auto&query=" + info.selectionText, '_blank');
     })
 }
 


### PR DESCRIPTION
opening the linguee tab next to the origin tab is visually indicating that the linguee tab belongs to the origin tab. Also, if you close the linguee tab, chrome will go back to the origin tab which improves the workflow of reading and translating.